### PR TITLE
Disable PWA service worker cache for local development; update cache version and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,12 @@ Note that you need to manually unmute by clicking the 🔇 button. This is due t
 
 You can't use `cargo test` directly since that would compile as wasm.
 `test.sh` runs the tests as a native binary.
+
+## Local development
+```
+trunk serve
+```
+Then open http://127.0.0.1:8080/#dev
+The #dev disables the pwa cache so that we get the latest version of the page.
+
+When you want to deploy to production you should make sure to update `cacheName` in `sw.js` to invalidate the cache.

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 - [x] Only show "click to enable audio" hint when unitialized, not when muted
 - [x] Add agent instructions for where and how to put temporary tools. make sure the temporary tools are added to .gitignore
 - [x] Make sure log::debug logs are sent to the browser console in dev builds
-- [ ] Make sure pwa service worker caches are disabled for local development. currently not even using #dev works. I need to "hard reload". And if I just f5 reload afterwards it goes back to the outdated cache.
+- [x] Make sure pwa service worker caches are disabled for local development. currently not even using #dev works. I need to "hard reload". And if I just f5 reload afterwards it goes back to the outdated cache.
 - [x] interval.rs: perhaps this is overcomplicated. better to just use the base_dissonance directly?
   - [x] Create a simplified version that only uses base_dissonance values
   - [x] Make sure the dissonance values makes sense for a tempered piano

--- a/assets/sw.js
+++ b/assets/sw.js
@@ -1,4 +1,4 @@
-const cacheName = "dissonance-lab-pwa-v15";
+const cacheName = "dissonance-lab-pwa-v16";
 const filesToCache = [
   "./",
   "./index.html",

--- a/index.html
+++ b/index.html
@@ -146,8 +146,7 @@
         const isTest = window.location.hash === "#test";
         const isLocalhost = window.location.hostname === 'localhost' || 
                            window.location.hostname === '127.0.0.1' ||
-                           window.location.hostname === '0.0.0.0' ||
-                           window.location.port !== '';
+                           window.location.hostname === '0.0.0.0';
         
         const shouldUseServiceWorker = isTest || (!isDev && !isLocalhost);
         

--- a/index.html
+++ b/index.html
@@ -144,9 +144,11 @@
         
         const isDev = window.location.hash === "#dev";
         const isTest = window.location.hash === "#test";
-        const isLocalhost = window.location.hostname === 'localhost' || 
-                           window.location.hostname === '127.0.0.1' ||
-                           window.location.hostname === '0.0.0.0';
+        const isLocalhost = (
+            window.location.hostname === 'localhost' ||
+            window.location.hostname === '127.0.0.1' ||
+            window.location.hostname === '[::1]'
+        );
         
         const shouldUseServiceWorker = isTest || (!isDev && !isLocalhost);
         
@@ -162,26 +164,28 @@
                 });
             } else if (isDev) {
                 // Development mode: unregister service workers and clear caches
-                navigator.serviceWorker.getRegistrations().then(function(registrations) {
-                    for(const registration of registrations) {
-                        registration.unregister().then(function(success) {
+                (async function() {
+                    try {
+                        const registrations = await navigator.serviceWorker.getRegistrations();
+                        for(const registration of registrations) {
+                            const success = await registration.unregister();
                             console.log('Service worker unregistered for development:', success);
-                        });
-                    }
-                });
-                
-                // Clear any existing caches
-                if ('caches' in window) {
-                    caches.keys().then(function(names) {
-                        for (const name of names) {
-                            caches.delete(name).then(function(success) {
-                                if (success) console.log('Cache cleared for development:', name);
-                            });
                         }
-                    });
-                }
-                
-                console.log('Development mode: Service worker disabled and caches cleared');
+                        
+                        // Clear any existing caches
+                        if ('caches' in window) {
+                            const names = await caches.keys();
+                            for (const name of names) {
+                                const success = await caches.delete(name);
+                                if (success) console.log('Cache cleared for development:', name);
+                            }
+                        }
+                    } catch (error) {
+                        console.error('Error in development mode cleanup:', error);
+                    }
+                    
+                    console.log('Development mode: Service worker disabled and caches cleared');
+                })();
             } else {
                 console.log('Localhost detected: Service worker disabled (use #test to enable)');
             }

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
                 // Clear any existing caches
                 if ('caches' in window) {
                     caches.keys().then(function(names) {
-                        for (let name of names) {
+                        for (const name of names) {
                             caches.delete(name).then(function(success) {
                                 if (success) console.log('Cache cleared for development:', name);
                             });

--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
             } else if (isDev) {
                 // Development mode: unregister service workers and clear caches
                 navigator.serviceWorker.getRegistrations().then(function(registrations) {
-                    for(let registration of registrations) {
+                    for(const registration of registrations) {
                         registration.unregister().then(function(success) {
                             console.log('Service worker unregistered for development:', success);
                         });

--- a/index.html
+++ b/index.html
@@ -137,11 +137,55 @@
     <!--Register Service Worker. this will cache the wasm / js scripts for offline use (for PWA functionality). -->
     <!-- Force refresh (Ctrl + F5) to load the latest files instead of cached files  -->
     <script>
-        // We disable caching during development so that we always view the latest version.
-        if ('serviceWorker' in navigator && window.location.hash !== "#dev") {
-            window.addEventListener('load', function () {
-                navigator.serviceWorker.register('sw.js');
-            });
+        // Service worker control for different modes:
+        // - #dev: Disable service worker and clear caches (for development)
+        // - #test: Enable service worker even on localhost (for testing PWA features)
+        // - default: Enable service worker only in production (not localhost)
+        
+        const isDev = window.location.hash === "#dev";
+        const isTest = window.location.hash === "#test";
+        const isLocalhost = window.location.hostname === 'localhost' || 
+                           window.location.hostname === '127.0.0.1' ||
+                           window.location.hostname === '0.0.0.0' ||
+                           window.location.port !== '';
+        
+        const shouldUseServiceWorker = isTest || (!isDev && !isLocalhost);
+        
+        if ('serviceWorker' in navigator) {
+            if (shouldUseServiceWorker) {
+                // Register service worker
+                window.addEventListener('load', function () {
+                    navigator.serviceWorker.register('sw.js').then(function(registration) {
+                        console.log('Service worker registered:', registration);
+                    }).catch(function(error) {
+                        console.log('Service worker registration failed:', error);
+                    });
+                });
+            } else if (isDev) {
+                // Development mode: unregister service workers and clear caches
+                navigator.serviceWorker.getRegistrations().then(function(registrations) {
+                    for(let registration of registrations) {
+                        registration.unregister().then(function(success) {
+                            console.log('Service worker unregistered for development:', success);
+                        });
+                    }
+                });
+                
+                // Clear any existing caches
+                if ('caches' in window) {
+                    caches.keys().then(function(names) {
+                        for (let name of names) {
+                            caches.delete(name).then(function(success) {
+                                if (success) console.log('Cache cleared for development:', name);
+                            });
+                        }
+                    });
+                }
+                
+                console.log('Development mode: Service worker disabled and caches cleared');
+            } else {
+                console.log('Localhost detected: Service worker disabled (use #test to enable)');
+            }
         }
     </script>
 </body>


### PR DESCRIPTION
Service worker registration logic now disables caching and clears caches when using #dev mode or running on localhost, improving development workflow. Updated cacheName in sw.js to invalidate old caches. Added documentation for local development and cache control in README.md.