### PR TITLE
Eager audio init & synth startup refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "ab_glyph_rasterizer"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2187590a23ab1e3df8681afdf0987c48504d80291f002fcdb651f0ef5e25169"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "addr2line"
@@ -106,9 +106,9 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -136,29 +136,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arboard"
@@ -169,7 +169,7 @@ dependencies = [
  "clipboard-win",
  "image",
  "log",
- "objc2 0.6.1",
+ "objc2 0.6.2",
  "objc2-app-kit 0.3.1",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -356,18 +356,18 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441473f2b4b0459a68628c744bc61d23e730fb00128b841d30fa4bb3972257e4"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -414,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+checksum = "5d07aa9a93b00c76f71bc35d598bed923f6d4f3a9ca5c24b7737ae1a292841c0"
 dependencies = [
  "serde",
 ]
@@ -440,7 +440,7 @@ dependencies = [
  "serde",
  "serde-untagged",
  "serde-value",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "toml",
  "unicode-xid",
  "url",
@@ -458,14 +458,14 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.31"
+version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
+checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
 dependencies = [
  "jobserver",
  "libc",
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.42"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.42"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -819,7 +819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.9.1",
- "objc2 0.6.1",
+ "objc2 0.6.2",
 ]
 
 [[package]]
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "dissonance-lab"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -856,7 +856,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "shared-types",
  "strum_macros 0.27.2",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -896,9 +896,9 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "ecolor"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a631732d995184114016fab22fc7e3faf73d6841c2d7650395fe251fbcd9285"
+checksum = "b6a7fc3172c2ef56966b2ce4f84177e159804c40b9a84de8861558ce4a59f422"
 dependencies = [
  "bytemuck",
  "emath",
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790ccfbb3dd556588342463454b2b2b13909e5fdce5bc2a1432a8aa69c8b7a"
+checksum = "34037a80dc03a4147e1684bff4e4fdab2b1408d715d7b78470cd3179258964b9"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8470210c95a42cc985d9ffebfd5067eea55bdb1c3f7611484907db9639675e28"
+checksum = "49e2be082f77715496b4a39fdc6f5dc7491fefe2833111781b8697ea6ee919a7"
 dependencies = [
  "ahash",
  "bitflags 2.9.1",
@@ -959,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14de9942d8b9e99e2d830403c208ab1a6e052e925a7456a4f6f66d567d90de1d"
+checksum = "64c7277a171ec1b711080ddb3b0bfa1b3aa9358834d5386d39e83fbc16d61212"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -979,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c490804a035cec9c826082894a3e1ecf4198accd3817deb10f7919108ebafab0"
+checksum = "fe6d8b0f8d6de4d43e794e343f03bacc3908aada931f0ed6fd7041871388a590"
 dependencies = [
  "ahash",
  "arboard",
@@ -998,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44f3fd4fdc5f960c9e9ef7327c26647edc3141abf96102980647129d49358e6"
+checksum = "0ab645760288e42eab70283a5cccf44509a6f43b554351855d3c73594bfe3c23"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1022,9 +1022,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f057b141e7e46340c321400be74b793543b1b213036f0f989c35d35957c32e"
+checksum = "935df67dc48fdeef132f2f7ada156ddc79e021344dd42c17f066b956bb88dde3"
 dependencies = [
  "bytemuck",
 ]
@@ -1060,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cca02195f0552c17cabdc02f39aa9ab6fbd815dac60ab1cd3d5b0aa6f9551c"
+checksum = "b66fc0a5a9d322917de9bd3ac7d426ca8aa3127fbf1e76fae5b6b25e051e06a3"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1078,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8495e11ed527dff39663b8c36b6c2b2799d7e4287fb90556e455d72eca0b4d3"
+checksum = "4f6cf8ce0fb817000aa24f5e630bda904a353536bd430b83ebc1dceee95b4a3a"
 
 [[package]]
 name = "equivalent"
@@ -1285,7 +1285,7 @@ dependencies = [
  "glutin_glx_sys",
  "glutin_wgl_sys",
  "libloading",
- "objc2 0.6.1",
+ "objc2 0.6.2",
  "objc2-app-kit 0.3.1",
  "objc2-core-foundation",
  "objc2-foundation 0.3.1",
@@ -1350,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
@@ -1704,9 +1704,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -1816,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "midir"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e77a0c42a20fdcb979064b996b7ba8a0030a866832d6ea5ab689a0688ef3a9"
+checksum = "554b64aee62310653a38da7ab34f96a41d9a94cfc5a6dc6f07872e07acb30e69"
 dependencies = [
  "alsa",
  "bitflags 1.3.2",
@@ -1878,7 +1878,7 @@ dependencies = [
  "once_cell",
  "rustc-hash 1.1.0",
  "strum",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "unicode-ident",
 ]
 
@@ -2026,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
+checksum = "561f357ba7f3a2a61563a186a163d0a3a5247e1089524a3981d49adb775078bc"
 dependencies = [
  "objc2-encode",
 ]
@@ -2056,7 +2056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
  "bitflags 2.9.1",
- "objc2 0.6.1",
+ "objc2 0.6.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation 0.3.1",
@@ -2106,7 +2106,7 @@ checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
  "bitflags 2.9.1",
  "dispatch2",
- "objc2 0.6.1",
+ "objc2 0.6.2",
 ]
 
 [[package]]
@@ -2117,7 +2117,7 @@ checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
  "bitflags 2.9.1",
  "dispatch2",
- "objc2 0.6.1",
+ "objc2 0.6.2",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
@@ -2172,7 +2172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
  "bitflags 2.9.1",
- "objc2 0.6.1",
+ "objc2 0.6.2",
  "objc2-core-foundation",
 ]
 
@@ -2183,7 +2183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
 dependencies = [
  "bitflags 2.9.1",
- "objc2 0.6.1",
+ "objc2 0.6.2",
  "objc2-core-foundation",
 ]
 
@@ -2457,9 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -2510,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -2688,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -2739,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "serde-untagged"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+checksum = "34836a629bcbc6f1afdf0907a744870039b1e14c0561cb26094fa683b158eff3"
 dependencies = [
  "erased-serde",
  "serde",
@@ -2850,9 +2850,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -2871,9 +2871,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slotmap"
@@ -2999,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3051,11 +3051,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.14",
 ]
 
 [[package]]
@@ -3071,9 +3071,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3644,7 +3644,7 @@ dependencies = [
  "jni",
  "log",
  "ndk-context",
- "objc2 0.6.1",
+ "objc2 0.6.2",
  "objc2-foundation 0.3.1",
  "url",
  "web-sys",
@@ -3705,7 +3705,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-types",
@@ -3735,7 +3735,7 @@ dependencies = [
  "portable-atomic",
  "raw-window-handle",
  "renderdoc-sys",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "wgpu-types",
 ]
 
@@ -3749,7 +3749,7 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "web-sys",
 ]
 
@@ -4381,9 +4381,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,11 @@ web-sys = { version = "0.3.70", features = [
 
 [package]
 name = "dissonance-lab"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Joel Nises <joel.nises@gmail.com>"]
 edition = "2024"
 include = ["LICENSE", "**/*.rs", "Cargo.toml"]
-rust-version = "1.88"
+rust-version = "1.89"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/assets/sw.js
+++ b/assets/sw.js
@@ -1,4 +1,4 @@
-const cacheName = "dissonance-lab-pwa-v21";
+const cacheName = "dissonance-lab-pwa-v22";
 const filesToCache = [
   "./",
   "./index.html",

--- a/audio-worklet/Cargo.toml
+++ b/audio-worklet/Cargo.toml
@@ -3,7 +3,7 @@ name = "audio-worklet"
 version = "0.0.1"
 authors = ["Joel Nises <joel.nises@gmail.com>"]
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.89"
 
 [lib]
 crate-type = ["cdylib"]

--- a/audio-worklet/src/lib.rs
+++ b/audio-worklet/src/lib.rs
@@ -39,7 +39,7 @@ impl DissonanceProcessor {
         let sample_rate = global.sample_rate();
 
         let processor = DissonanceProcessor {
-            synth: synth::PianoSynth::new(),
+            synth: synth::PianoSynth::with_sample_rate(sample_rate as u32),
             sample_rate,
             port: None,
             interleaved_buffer_cache: Vec::new(),

--- a/audio-worklet/src/synth.rs
+++ b/audio-worklet/src/synth.rs
@@ -371,13 +371,13 @@ impl PianoSynth {
     }
 
     fn allocate_voices_if_needed(&mut self) {
-        if self.voices.is_empty() {
-            if let Some(sr) = self.sample_rate {
-                const NUM_VOICES: usize = 8;
-                self.voices.reserve(NUM_VOICES);
-                for _ in 0..NUM_VOICES {
-                    self.voices.push(PianoVoice::new(sr as f32));
-                }
+        if self.voices.is_empty()
+            && let Some(sr) = self.sample_rate
+        {
+            const NUM_VOICES: usize = 8;
+            self.voices.reserve(NUM_VOICES);
+            for _ in 0..NUM_VOICES {
+                self.voices.push(PianoVoice::new(sr as f32));
             }
         }
     }
@@ -476,10 +476,10 @@ impl PianoSynth {
     /// Actually release a note (used both for normal note-off and when sustain pedal is released)
     fn release_note(&mut self, midi_note: wmidi::Note) {
         for voice in self.voices.iter_mut() {
-            if let Some(key) = &voice.current_key {
-                if key.midi_note == midi_note {
-                    voice.note_off();
-                }
+            if let Some(key) = &voice.current_key
+                && key.midi_note == midi_note
+            {
+                voice.note_off();
             }
         }
     }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,6 +5,6 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "1.88"  # Avoid specifying a patch version here; see https://github.com/emilk/eframe_template/issues/145
+channel = "1.89"  # Avoid specifying a patch version here; see https://github.com/emilk/eframe_template/issues/145
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/src/app.rs
+++ b/src/app.rs
@@ -71,7 +71,7 @@ impl DissonanceLabApp {
         app.load_sustain_pedal_setting(cc);
         // Try to eagerly initialize audio once at startup in case the browser allows it without user gesture.
         // Some browsers (notably Safari / iOS) will reject or suspend AudioContext creation until a user gesture.
-        // If initialization ultimately fails we will revert the state back to Uninitialized so the user can click the button.
+        // If initialization ultimately fails we will revert the state back to Uninitialized so the user can click the audio enable/unmute button in the UI.
         app.try_startup_audio_once();
         app
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -77,10 +77,10 @@ impl DissonanceLabApp {
     }
 
     fn load_sustain_pedal_setting(&mut self, cc: &eframe::CreationContext<'_>) {
-        if let Some(storage) = cc.storage {
-            if let Some(invert_sustain) = storage.get_string("invert_sustain_pedal") {
-                self.invert_sustain_pedal = invert_sustain == "true";
-            }
+        if let Some(storage) = cc.storage
+            && let Some(invert_sustain) = storage.get_string("invert_sustain_pedal")
+        {
+            self.invert_sustain_pedal = invert_sustain == "true";
         }
     }
 
@@ -118,15 +118,15 @@ impl DissonanceLabApp {
     /// Check if the current audio state indicates failure and update to Disabled if so
     fn check_audio_status(&mut self) {
         let mut audio_guard = self.audio.lock().unwrap();
-        if let AudioState::Playing(web_audio) = &*audio_guard {
-            if web_audio.is_disabled() {
-                if !self.user_audio_attempted {
-                    // Automatic attempt failed / unsupported. Revert to Uninitialized so user can try enabling manually.
-                    *audio_guard = AudioState::Uninitialized;
-                } else {
-                    // User explicitly tried and it still failed; mark Disabled so we can show more explicit UI.
-                    *audio_guard = AudioState::Disabled;
-                }
+        if let AudioState::Playing(web_audio) = &*audio_guard
+            && web_audio.is_disabled()
+        {
+            if !self.user_audio_attempted {
+                // Automatic attempt failed / unsupported. Revert to Uninitialized so user can try enabling manually.
+                *audio_guard = AudioState::Uninitialized;
+            } else {
+                // User explicitly tried and it still failed; mark Disabled so we can show more explicit UI.
+                *audio_guard = AudioState::Disabled;
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -34,6 +34,10 @@ pub struct DissonanceLabApp {
     midi_to_piano_gui_rx: channel::Receiver<wmidi::MidiMessage<'static>>,
     midi_to_piano_gui_tx: channel::Sender<wmidi::MidiMessage<'static>>,
     invert_sustain_pedal: bool,
+    // Whether we already performed the automatic startup attempt
+    auto_audio_attempted: bool,
+    // Whether the user has explicitly attempted to enable audio (clicked the button)
+    user_audio_attempted: bool,
 }
 
 impl Default for DissonanceLabApp {
@@ -46,6 +50,8 @@ impl Default for DissonanceLabApp {
             midi_to_piano_gui_rx,
             midi_to_piano_gui_tx,
             invert_sustain_pedal: false,
+            auto_audio_attempted: false,
+            user_audio_attempted: false,
         }
     }
 }
@@ -63,6 +69,10 @@ impl DissonanceLabApp {
         let mut app = Self::default();
         // Load sustain pedal polarity setting from local storage
         app.load_sustain_pedal_setting(cc);
+        // Try to eagerly initialize audio once at startup in case the browser allows it without user gesture.
+        // Some browsers (notably Safari / iOS) will reject or suspend AudioContext creation until a user gesture.
+        // If initialization ultimately fails we will revert the state back to Uninitialized so the user can click the button.
+        app.try_startup_audio_once();
         app
     }
 
@@ -90,6 +100,19 @@ impl DissonanceLabApp {
         ));
         let web_audio = WebAudio::new();
         *self.audio.lock().unwrap() = AudioState::Playing(web_audio);
+        self.user_audio_attempted = true;
+    }
+
+    /// Attempt to start audio during startup (no user gesture yet).
+    /// If the worklet later reports a disable state, revert to Uninitialized so the user can try again manually.
+    fn try_startup_audio_once(&mut self) {
+        // Only attempt if currently uninitialized – don't override an explicit user mute choice.
+        if matches!(*self.audio.lock().unwrap(), AudioState::Uninitialized) {
+            // Move into a Playing state to kick off async loading.
+            let web_audio = WebAudio::new();
+            *self.audio.lock().unwrap() = AudioState::Playing(web_audio);
+            self.auto_audio_attempted = true;
+        }
     }
 
     /// Check if the current audio state indicates failure and update to Disabled if so
@@ -97,7 +120,13 @@ impl DissonanceLabApp {
         let mut audio_guard = self.audio.lock().unwrap();
         if let AudioState::Playing(web_audio) = &*audio_guard {
             if web_audio.is_disabled() {
-                *audio_guard = AudioState::Disabled;
+                if !self.user_audio_attempted {
+                    // Automatic attempt failed / unsupported. Revert to Uninitialized so user can try enabling manually.
+                    *audio_guard = AudioState::Uninitialized;
+                } else {
+                    // User explicitly tried and it still failed; mark Disabled so we can show more explicit UI.
+                    *audio_guard = AudioState::Disabled;
+                }
             }
         }
     }
@@ -116,11 +145,13 @@ impl DissonanceLabApp {
                     if let AudioState::Playing(web_audio) = &*audio.lock().unwrap() {
                         match message {
                             wmidi::MidiMessage::NoteOff(_, note, _) => {
+                                web_audio.ensure_running();
                                 web_audio.send_message(ToWorkletMessage::NoteOff {
                                     note: u8::from(*note),
                                 });
                             }
                             wmidi::MidiMessage::NoteOn(_, note, velocity) => {
+                                web_audio.ensure_running();
                                 web_audio.send_message(ToWorkletMessage::NoteOn {
                                     note: u8::from(*note),
                                     velocity: u8::from(*velocity),
@@ -429,6 +460,7 @@ impl eframe::App for DissonanceLabApp {
                                             if let AudioState::Playing(web_audio) =
                                                 &*self.audio.lock().unwrap()
                                             {
+                                                web_audio.ensure_running();
                                                 web_audio.send_message(
                                                     ToWorkletMessage::SustainPedal { active },
                                                 );
@@ -438,6 +470,7 @@ impl eframe::App for DissonanceLabApp {
                                         }
                                         piano_gui::Action::Released(note) => {
                                             if let AudioState::Playing(web_audio) = &*self.audio.lock().unwrap() {
+                                                web_audio.ensure_running();
                                                 web_audio.send_message(ToWorkletMessage::NoteOff {
                                                     note: u8::from(note),
                                                 });
@@ -460,6 +493,7 @@ impl eframe::App for DissonanceLabApp {
                     match action {
                         piano_gui::Action::Pressed(note) => {
                             if let AudioState::Playing(web_audio) = &*self.audio.lock().unwrap() {
+                                web_audio.ensure_running();
                                 web_audio.send_message(ToWorkletMessage::NoteOn {
                                     note: u8::from(note),
                                     velocity: 64,
@@ -468,6 +502,7 @@ impl eframe::App for DissonanceLabApp {
                         }
                         piano_gui::Action::Released(note) => {
                             if let AudioState::Playing(web_audio) = &*self.audio.lock().unwrap() {
+                                web_audio.ensure_running();
                                 web_audio.send_message(ToWorkletMessage::NoteOff {
                                     note: u8::from(note),
                                 });
@@ -475,6 +510,7 @@ impl eframe::App for DissonanceLabApp {
                         }
                         piano_gui::Action::SustainPedal(active) => {
                             if let AudioState::Playing(web_audio) = &*self.audio.lock().unwrap() {
+                                web_audio.ensure_running();
                                 web_audio.send_message(ToWorkletMessage::SustainPedal { active });
                             }
                             // Request immediate repaint to update the sustain label color

--- a/src/webaudio.rs
+++ b/src/webaudio.rs
@@ -195,7 +195,9 @@ impl WebAudio {
     /// Browsers may start the context suspended until a user gesture occurs. When we
     /// auto-initialize audio at startup this can result in a "playing" state with no sound
     /// until the user clicks mute/unmute. Calling this before sending note messages will
-    /// resume the context once a gesture has occurred (e.g., piano key press).
+    /// until the user performs a gesture (such as clicking mute/unmute or pressing a piano key).
+    /// Calling this before sending note messages will resume the context once a gesture has occurred
+    /// (e.g., piano key press, mute/unmute click, or any other user interaction).
     pub fn ensure_running(&self) {
         if let Some(node) = self.node.try_get()
             && let Ok(connection) = node.as_ref()

--- a/src/webaudio.rs
+++ b/src/webaudio.rs
@@ -178,10 +178,41 @@ impl WebAudio {
             false // Still loading
         }
     }
+
+    /// Check if the audio worklet finished initializing successfully
+    ///
+    /// Returns true only once the underlying Future has resolved Ok
+    pub fn is_ready(&self) -> bool {
+        if let Some(node) = self.node.try_get() {
+            node.is_ok()
+        } else {
+            false // Still loading
+        }
+    }
+
+    /// Ensure the underlying AudioContext is in a running state.
+    ///
+    /// Browsers may start the context suspended until a user gesture occurs. When we
+    /// auto-initialize audio at startup this can result in a "playing" state with no sound
+    /// until the user clicks mute/unmute. Calling this before sending note messages will
+    /// resume the context once a gesture has occurred (e.g., piano key press).
+    pub fn ensure_running(&self) {
+        if let Some(node) = self.node.try_get() {
+            if let Ok(connection) = node.as_ref() {
+                // We don't have access to AudioContext.state via web-sys yet on all targets, so just attempt resume.
+                // Browsers ignore resume() if already running.
+                if let Err(e) = connection.context.resume() {
+                    // Ignored: can fail prior to a valid user gesture; we'll try again next event.
+                    log::debug!("AudioContext resume attempt failed or deferred: {e:?}");
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
 struct AudioNodeConnection {
+    context: AudioContext,
     node: AudioWorkletNode,
     // needs to be kept alive
     _onmessage: Closure<dyn FnMut(MessageEvent)>,
@@ -233,6 +264,7 @@ impl AudioNodeConnection {
         port.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
 
         Self {
+            context,
             node,
             _onmessage: onmessage,
         }


### PR DESCRIPTION
# Summary
Refactors audio and synth initialization to start eagerly for more reliable first-note playback and simpler control flow.

# Key Changes
- Eager WebAudio + synth setup (`src/webaudio.rs`, `src/app.rs`)
- Synth init & logic refactor (`audio-worklet/src/synth.rs`)
- Rust toolchain bump to 1.89 + dependency updates (`Cargo.toml`, `Cargo.lock`, `rust-toolchain`)
- Simplified nested conditionals (Clippy cleanup)

