### PR TITLE
Fix MIDI note-off and touch handling

### DIFF
--- a/audio-worklet/src/lib.rs
+++ b/audio-worklet/src/lib.rs
@@ -63,8 +63,12 @@ impl DissonanceProcessor {
             ToWorkletMessage::NoteOn { note, velocity } => {
                 log::debug!("NoteOn: note={note}, velocity={velocity}");
                 let midi_note = wmidi::Note::try_from(note).expect("Invalid MIDI note value");
-                let midi_velocity = wmidi::U7::try_from(velocity).unwrap_or(wmidi::U7::MAX);
-                self.synth.note_on(midi_note, midi_velocity);
+                if velocity == 0 {
+                    self.synth.note_off(midi_note);
+                } else {
+                    let midi_velocity = wmidi::U7::try_from(velocity).unwrap_or(wmidi::U7::MAX);
+                    self.synth.note_on(midi_note, midi_velocity);
+                }
             }
             ToWorkletMessage::NoteOff { note } => {
                 log::debug!("NoteOff: note={note}");

--- a/src/app.rs
+++ b/src/app.rs
@@ -152,10 +152,16 @@ impl DissonanceLabApp {
                             }
                             wmidi::MidiMessage::NoteOn(_, note, velocity) => {
                                 web_audio.ensure_running();
-                                web_audio.send_message(ToWorkletMessage::NoteOn {
-                                    note: u8::from(*note),
-                                    velocity: u8::from(*velocity),
-                                });
+                                if u8::from(*velocity) == 0 {
+                                    web_audio.send_message(ToWorkletMessage::NoteOff {
+                                        note: u8::from(*note),
+                                    });
+                                } else {
+                                    web_audio.send_message(ToWorkletMessage::NoteOn {
+                                        note: u8::from(*note),
+                                        velocity: u8::from(*velocity),
+                                    });
+                                }
                             }
                             wmidi::MidiMessage::ControlChange(_, control, _value) => {
                                 // Check for sustain pedal (control 64)
@@ -436,8 +442,12 @@ impl eframe::App for DissonanceLabApp {
                         wmidi::MidiMessage::NoteOff(_channel, note, _) => {
                             self.piano_gui.external_note_off(note);
                         }
-                        wmidi::MidiMessage::NoteOn(_channel, note, _) => {
-                            self.piano_gui.external_note_on(note);
+                        wmidi::MidiMessage::NoteOn(_channel, note, velocity) => {
+                            if u8::from(velocity) == 0 {
+                                self.piano_gui.external_note_off(note);
+                            } else {
+                                self.piano_gui.external_note_on(note);
+                            }
                         }
                         wmidi::MidiMessage::ControlChange(_, control, value) => {
                             // Check for sustain pedal (control 64)

--- a/src/piano_gui.rs
+++ b/src/piano_gui.rs
@@ -23,6 +23,9 @@ pub struct PianoGui {
     /// Maps each note to the set of pointers currently pressing it.
     /// Enables multi-touch: multiple fingers can press the same key simultaneously.
     pointers_holding_key: HashMap<wmidi::Note, HashSet<PointerId>>,
+
+    /// Touch identifiers that are currently active, even if they are outside piano keys.
+    active_touch_ids: HashSet<u64>,
 }
 
 impl PianoGui {
@@ -31,6 +34,7 @@ impl PianoGui {
             state: PianoState::new(),
             key_held_by_pointer: HashMap::new(),
             pointers_holding_key: HashMap::new(),
+            active_touch_ids: HashSet::new(),
         }
     }
 
@@ -72,19 +76,22 @@ impl PianoGui {
         // Process all pointer events (touch and mouse)
 
         // Handle touch events
-        let mut has_active_touches = false;
+        let mut has_active_touches = !self.active_touch_ids.is_empty();
         ui.input(|i| {
             for event in &i.events {
                 if let Event::Touch { id, phase, pos, .. } = event {
                     has_active_touches = true;
-                    let pointer_id = PointerId::Touch(id.0);
+                    let touch_id = id.0;
+                    let pointer_id = PointerId::Touch(touch_id);
 
                     match phase {
                         TouchPhase::Start | TouchPhase::Move => {
+                            self.active_touch_ids.insert(touch_id);
                             let target_note = self.find_key_at_position(*pos, keys_rect);
                             self.handle_pointer_move(pointer_id, target_note);
                         }
                         TouchPhase::End | TouchPhase::Cancel => {
+                            self.active_touch_ids.remove(&touch_id);
                             self.handle_pointer_release(pointer_id);
                         }
                     }


### PR DESCRIPTION
## Summary
- Treat MIDI NoteOn messages with velocity 0 as note-off in both the UI and worklet paths
- Track active touch IDs separately so touch input suppresses mouse handling until touches end/cancel, even when a touch moves outside piano keys
- Narrow PR scope to the targeted MIDI/touch fix commit only

## Validation
- cargo xtask check --skip-fmt